### PR TITLE
Improve mobile layout and add tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "winston": "^3.17.0"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
@@ -55,7 +55,9 @@
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.3",
     "tailwindcss-scrollbar": "^0.1.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.4"
   },
   "keywords": [],
   "author": "",

--- a/pages/index.js
+++ b/pages/index.js
@@ -921,7 +921,7 @@ export default function Dashboard() {
             </div>
 
             <div className="grid grid-cols-1 md:grid-cols-8 gap-6">
-              <div className="md:col-span-3 p-4 sm:p-6 bg-white dark:bg-gray-800 rounded-xl shadow-lg flex flex-col h-[500px]">
+              <div className="md:col-span-3 p-4 sm:p-6 bg-white dark:bg-gray-800 rounded-xl shadow-lg flex flex-col sm:h-[500px] h-auto">
                 <h2 className="text-xl font-semibold mb-4 text-gray-700 dark:text-gray-300">Request Ad-Hoc Crawl</h2>
                 <form onSubmit={handleTestSubmit} className="flex flex-col flex-grow space-y-4">
                   <div>
@@ -973,7 +973,7 @@ export default function Dashboard() {
                       Capture Video for Failed URLs
                     </label>
                   </div>
-                  <div className="flex items-center mt-auto">
+                  <div className="flex flex-col sm:flex-row items-center mt-auto space-y-2 sm:space-y-0 sm:space-x-4">
                     <div>
                       <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1" htmlFor="file">
                         Select input.xlsx
@@ -990,7 +990,7 @@ export default function Dashboard() {
                     <button
                       type="submit"
                       disabled={submissionStatus === 'loading'}
-                      className="ml-auto px-5 py-2.5 bg-green-600 hover:bg-green-700 text-white rounded-lg font-medium text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 disabled:opacity-60"
+                      className="sm:ml-auto px-5 py-2.5 bg-green-600 hover:bg-green-700 text-white rounded-lg font-medium text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 disabled:opacity-60"
                     >
                       {submissionStatus === 'loading' ? 'Submitting...' : 'Run Test'}
                     </button>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -93,3 +93,12 @@ th, td {
   scrollbar-color: #555 transparent; /* Darker thumb for Firefox in dark mode */
 }
 
+@media (max-width: 640px) {
+  .custom-scrollbar::-webkit-scrollbar {
+    width: 4px;
+  }
+  .custom-scrollbar {
+    scrollbar-width: thin; /* ensure thin width on mobile */
+  }
+}
+

--- a/tests/validate-gemini-passphrase.test.js
+++ b/tests/validate-gemini-passphrase.test.js
@@ -1,0 +1,30 @@
+import express from 'express';
+import request from 'supertest';
+import handler from '../pages/api/validate-gemini-passphrase.js';
+
+const app = express();
+app.use(express.json());
+app.post('/api/validate-gemini-passphrase', (req, res) => handler(req, res));
+
+describe('validate-gemini-passphrase', () => {
+  const VALID = 'test-pass';
+  beforeAll(() => {
+    process.env.GEMINI_PASSPHRASE = VALID;
+  });
+
+  test('returns 200 for valid passphrase', async () => {
+    const res = await request(app)
+      .post('/api/validate-gemini-passphrase')
+      .send({ passphrase: VALID });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ valid: true });
+  });
+
+  test('returns 401 for invalid passphrase', async () => {
+    const res = await request(app)
+      .post('/api/validate-gemini-passphrase')
+      .send({ passphrase: 'bad' });
+    expect(res.status).toBe(401);
+    expect(res.body.valid).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- tweak Ad-Hoc Crawl card layout to stack controls on small screens
- reduce scrollbar width on mobile
- add Jest and Supertest configuration
- add tests for Gemini passphrase validation

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_683caba5616883218fd88fa6b87ea374