### PR TITLE
Filter cached runs by env

### DIFF
--- a/pages/api/get-runs.js
+++ b/pages/api/get-runs.js
@@ -8,11 +8,16 @@ export default async function handler(req, res) {
     return res.status(405).json({ message: 'Method not allowed' });
   }
 
-  const cacheKey = 'workflow_runs';
+  const envFilter = req.query.env;
+  const cacheKey = envFilter ? `workflow_runs_${envFilter}` : 'workflow_runs';
   const cachedData = cache.get(cacheKey);
   if (cachedData) {
     console.log('Returning cached data');
-    return res.status(200).json(cachedData);
+    let runs = cachedData;
+    if (envFilter) {
+      runs = cachedData.filter(run => run.environment === envFilter);
+    }
+    return res.status(200).json(runs);
   }
 
   try {
@@ -165,7 +170,6 @@ export default async function handler(req, res) {
       consumed: initialRateLimit.data.rate.remaining - finalRateLimit.data.rate.remaining
     });
 
-    const envFilter = req.query.env;
     let filteredRuns = validRuns;
     if (envFilter) {
       filteredRuns = validRuns.filter(run => {


### PR DESCRIPTION
## Summary
- filter cached run results by requested environment
- keep filtering when new data is fetched

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_683f2934119c8321aa425f550ce557c4